### PR TITLE
Allow Class (Constructor Function) as parameter for knot( )

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,41 +1,42 @@
 {
-  "name":        "knot.js",
-  "version":     "1.0.1",
+  "name": "knot.js",
+  "version": "1.0.1",
   "description": "A browser-based emitter, for tying together event handlers.",
-  "homepage":    "https://github.com/callmecavs/knot",
-  "main":        "dist/knot.min.js",
-
-  "author":  "Michael Cavalea",
+  "homepage": "https://github.com/callmecavs/knot",
+  "main": "dist/knot.min.js",
+  "author": "Michael Cavalea",
   "license": "MIT",
-
   "repository": {
     "type": "git",
-    "url":  "https://github.com/callmecavs/knot"
+    "url": "https://github.com/callmecavs/knot"
   },
   "bugs": {
     "url": "https://github.com/callmecavs/knot/issues"
   },
-
   "keywords": [
     "event",
     "emitter"
   ],
-
+  "scripts": {
+    "test": "./node_modules/.bin/mocha --compilers js:babel-register --watch --watch-extensions js"
+  },
   "devDependencies": {
-    "babel":                           "*",
-    "babel-preset-es2015":             "*",
+    "babel": "*",
     "babel-plugin-add-module-exports": "*",
-    "babelify":                        "*",
-    "browserify":                      "*",
-    "gulp":                            "*",
-    "gulp-connect":                    "*",
-    "gulp-header":                     "*",
-    "gulp-sourcemaps":                 "*",
-    "gulp-uglify":                     "*",
-    "lodash.assign":                   "*",
-    "node-notifier":                   "*",
-    "vinyl-buffer":                    "*",
-    "vinyl-source-stream":             "*",
-    "watchify":                        "*"
+    "babel-preset-es2015": "*",
+    "babelify": "*",
+    "browserify": "*",
+    "chai": "^3.5.0",
+    "gulp": "*",
+    "gulp-connect": "*",
+    "gulp-header": "*",
+    "gulp-sourcemaps": "*",
+    "gulp-uglify": "*",
+    "lodash.assign": "*",
+    "mocha": "^2.4.5",
+    "node-notifier": "*",
+    "vinyl-buffer": "*",
+    "vinyl-source-stream": "*",
+    "watchify": "*"
   }
 }

--- a/src/knot.js
+++ b/src/knot.js
@@ -1,41 +1,55 @@
 export default (object = {}) => {
-  object.events = {}
+  let decorated
 
-  object.on = (name, handler) => {
-    object.events[name] = object.events[name] || []
-    object.events[name].push(handler)
-    return object
+  if (checkIsFunction(object)) {
+    decorated = object.prototype
+  } else {
+    decorated = object
   }
 
-  object.once = (name, handler) => {
+  decorated.events = {}
+
+  decorated.on = function(name, handler) {
+    this.events[name] = this.events[name] || []
+    this.events[name].push(handler)
+
+    return this
+  }
+
+  decorated.once = function(name, handler) {
     handler._once = true
-    object.on(name, handler)
-    return object
+    this.on(name, handler)
+
+    return this
   }
 
-  object.off = function(name, handler) {
+  decorated.off = function(name, handler) {
     arguments.length === 2
-      ? object.events[name].splice(object.events[name].indexOf(handler), 1)
-      : delete object.events[name]
+      ? this.events[name].splice(this.events[name].indexOf(handler), 1)
+      : delete this.events[name]
 
-    return object
+    return this
   }
 
-  object.emit = function(name, ...args) {
+  decorated.emit = function(name, ...args) {
     // cache event state, to avoid consequences of mutation from splice while firing handlers
-    const cached = object.events[name] && object.events[name].slice()
+    const cached = this.events[name] && this.events[name].slice()
 
     // if they exist, fire handlers
     cached && cached.forEach(handler => {
       // remove handler if added with `once`
-      handler._once && object.off(name, handler)
+      handler._once && this.off(name, handler)
 
       // set `this` context in handler to object, pass in parameters
-      handler.apply(object, args)
+      handler.apply(this, args)
     })
 
-    return object
+    return this
   }
 
   return object
+}
+
+function checkIsFunction(toCheck) {
+  return toCheck && typeof toCheck === 'function'
 }

--- a/src/knot.js
+++ b/src/knot.js
@@ -5,8 +5,8 @@ export default (object = {}) => {
   if (checkIsFunction(object)) {
     // Inherit to add events, an own property
     class Knotted extends object {
-      constructor() {
-        super()
+      constructor(...args) {
+        super(...args)
         this.events = {}
       }
     }

--- a/src/knot.js
+++ b/src/knot.js
@@ -1,13 +1,23 @@
 export default (object = {}) => {
   let decorated
+  let result
 
   if (checkIsFunction(object)) {
-    decorated = object.prototype
+    // Inherit to add events, an own property
+    class Knotted extends object {
+      constructor() {
+        super()
+        this.events = {}
+      }
+    }
+    decorated = Knotted.prototype
+    // Result should be the constructor but not prototype
+    result = Knotted
   } else {
     decorated = object
+    decorated.events = {}
+    result = object
   }
-
-  decorated.events = {}
 
   decorated.on = function(name, handler) {
     this.events[name] = this.events[name] || []
@@ -47,7 +57,7 @@ export default (object = {}) => {
     return this
   }
 
-  return object
+  return result
 }
 
 function checkIsFunction(toCheck) {

--- a/test/test.js
+++ b/test/test.js
@@ -122,6 +122,12 @@ describe('knot', function() {
           assert.notEqual(subject.birthplaceToTell, subject.birthplace)
         })
       })
+
+      describe('#knot(target).events is own property', function() {
+        it('should not respond to deregistered event', function() {
+          assert.isOk(subject.hasOwnProperty('events'))
+        })
+      })
     })
   })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -6,7 +6,8 @@ const assert = chai.assert
 describe('knot', function() {
   // For Class based test
   class Subject {
-    constructor() {
+    constructor(passedInName) {
+      this.passedInName = passedInName
       this.name = 'knot.js'
       this.birthplace = 'Github'
       this.nameToTell = ''
@@ -43,7 +44,7 @@ describe('knot', function() {
   const tests = [{
     name: 'Class based',
     getSubject() {
-      return new KnottedSubject()
+      return new KnottedSubject('passed in')
     }
   }, {
     name: 'Object based',
@@ -128,6 +129,14 @@ describe('knot', function() {
           assert.isOk(subject.hasOwnProperty('events'))
         })
       })
+
+      if (test.name === 'Class based') {
+        describe('#knot(Class) returns new constructor', function() {
+          it('should preserve constructor arguments', function() {
+            assert.equal(subject.passedInName, 'passed in')
+          })
+        })
+      }
     })
   })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,127 @@
+import chai from 'chai'
+import knot from '../src/knot'
+
+const assert = chai.assert
+
+describe('knot', function() {
+  // For Class based test
+  class Subject {
+    constructor() {
+      this.name = 'knot.js'
+      this.birthplace = 'Github'
+      this.nameToTell = ''
+      this.birthplaceToTell = ''
+    }
+
+    tellName() {
+      this.nameToTell = this.name
+    }
+
+    tellBirthplace() {
+      this.birthplaceToTell = this.birthplace
+    }
+  }
+
+  const KnottedSubject = knot(Subject)
+
+  // For Object based test
+  const defaultSubject = {
+    name: 'knot.js',
+    birthplace: 'Github',
+    nameToTell: '',
+    birthplaceToTell: '',
+    tellName: function() {
+      this.nameToTell = this.name
+    },
+    tellBirthplace: function() {
+      this.birthplaceToTell = this.birthplace
+    }
+  }
+
+  let subject
+
+  const tests = [{
+    name: 'Class based',
+    getSubject() {
+      return new KnottedSubject()
+    }
+  }, {
+    name: 'Object based',
+    getSubject() {
+      return knot(Object.assign({}, defaultSubject))
+    }
+  }]
+
+  // Dynamically generate tests
+  tests.forEach(function(test) {
+    context(`knot(target) ${test.name}`, function() {
+      beforeEach(function() {
+        subject = test.getSubject()
+      })
+
+      describe('#knot(target) chainability', function() {
+        it('All methods should return the calling object', function() {
+          const chained = subject.on('a', () => {})
+            .once('b', () => {})
+            .off('a')
+            .emit('b')
+          assert.equal(chained, subject, 'All methods should return the calling object')
+        })
+      })
+
+      describe('#knot(target).on & emit', function() {
+        beforeEach(function() {
+          subject.on('tell-name', subject.tellName)
+        })
+
+        it('should not execute handler on registered', function() {
+          assert.notEqual(subject.nameToTell, subject.name)
+        })
+
+        it('should responds to event after registered', function() {
+          subject.emit('tell-name')
+          assert.equal(subject.nameToTell, subject.name)
+        })
+
+        it('should responds to event after registered more than once', function() {
+          subject.emit('tell-name')
+          assert.equal(subject.nameToTell, subject.name)
+          subject.nameToTell = ''
+          subject.emit('tell-name')
+          assert.equal(subject.nameToTell, subject.name)
+        })
+      })
+
+      describe('#knot(target).once', function() {
+        beforeEach(function() {
+          subject.once('tell-name', subject.tellName)
+        })
+
+        it('should not execute handler on registered', function() {
+          assert.notEqual(subject.nameToTell, subject.name)
+        })
+
+        it('should responds to event after registered once and only once', function() {
+          subject.emit('tell-name')
+          assert.equal(subject.nameToTell, subject.name)
+          subject.nameToTell = ''
+          subject.emit('tell-name')
+          assert.notEqual(subject.nameToTell, subject.name)
+        })
+      })
+
+      describe('#knot(target).off', function() {
+        it('should not respond to deregistered event', function() {
+          subject.on('tell-name', subject.tellName)
+            .once('tell-birthplace', subject.tellBirthplace)
+            .off('tell-name')
+            .off('tell-birthplace')
+            .emit('tell-name')
+            .emit('tell-birthplace')
+          assert.notEqual(subject.nameToTell, subject.name)
+          assert.notEqual(subject.birthplaceToTell, subject.birthplace)
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
# Why

knot( ) method currently takes an object as parameter, so typically we can use it like:

``` javascript
const foo = new Foo( );
foo = knot(foo);
foo.on( ).once( );
```

However, when I tried to use knot.js internally, I just want others don't need to know about knot.js. Something like:

``` javascript
const boo = new Boo( );
boo.on( ).once( )
```
# How to realize

One way is to use factory pattern, like the way you did in your awesome [bricks.js](https://github.com/callmecavs/bricks.js).

``` javascript
const brick = Brick( );
brick.on( );
```

However, factory pattern has its pros but also has cons, like more memory usage, cannot be inherited, etc.

So I propose another way to realize it, which is to pass Class (Constructor Function) to knot as a parameter.
The idea to is to take the Class and create a subclass inheriting from it, and the on, once, off, emit methods are added to the subclass's prototype.
This way, we can define a Class that internally uses knot.js while keeping this 'secret' from outside.

``` javascript
class Boo {
  constructor( ) { }
}

export default knot(Boo)
```
