### PR TITLE
Prevent errors with event names that collide with properties on Object.prototype

### DIFF
--- a/src/knot.js
+++ b/src/knot.js
@@ -1,5 +1,5 @@
 export default (object = {}) => {
-  const events = {}
+  const events = Object.create(null)
 
   function on(name, handler) {
     events[name] = events[name] || []


### PR DESCRIPTION
Right now, the following is an error:

```
const e = knot();
e.on( 'toString', console.log );
```

And you get a type error because `events[ name ].push is not a function`.

That's because the event cache inherits from `Object.prototype`. Thus, knot looks for `events.toString`, doesn't find it, continues up the prototype chain, and finds `Object.prototype.toString`. Then it tries to call `push` on it. But it's not an array, it's a function.

Instead, this defines `events` with `Object.create( null )`, ensuring the object has nothing in its prototype chain.